### PR TITLE
removing single bracket from twig config, adding twig brackets

### DIFF
--- a/src/languages/twig.configuration.json
+++ b/src/languages/twig.configuration.json
@@ -3,14 +3,16 @@
 		"blockComment": [ "{#", "#}" ]
 	},
 	"brackets": [
-		["{", "}"],
+		["{{", "}}"],
+		["{%", "%}"],
 		["[", "]"],
 		["(", ")"]
 	],
 	"surroundingPairs": [
 		{ "open": "'", "close": "'" },
 		{ "open": "\"", "close": "\"" },
-		{ "open": "{", "close": "}"},
+		{ "open": "{{", "close": "}}"},
+		{ "open": "{%", "close": "%}"},
 		{ "open": "[", "close": "]"},
 		{ "open": "(", "close": ")" },
 		{ "open": "<", "close": ">" }


### PR DESCRIPTION
This is an opinionated fix for https://github.com/mblode/vscode-twig-language/issues/34 but I belive that in twig we should make it easier to finish the logic and templating while sacrificing the single brackets.

Adds autocomplete to `{{` and `{%` while removing the `{` autocomplete.