### PR TITLE
Fix Twig CSS block end highlighting

### DIFF
--- a/src/syntaxes/twig.tmLanguage
+++ b/src/syntaxes/twig.tmLanguage
@@ -204,6 +204,59 @@
             </array>
         </dict>
         <dict>
+            <key>begin</key>
+            <string>(?ix)(\{%-?)\s*(css|includecss|includehirescss)\s*(-?%\})</string>
+            <key>beginCaptures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.section.tag.twig</string>
+                </dict>
+                <key>2</key>
+                <dict>
+                    <key>name</key>
+                    <string>keyword.control.twig</string>
+                </dict>
+                <key>3</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.section.tag.twig</string>
+                </dict>
+            </dict>
+            <key>comment</key>
+            <string>Add CSS support to set tags that use the pattern "css" in their name</string>
+            <key>end</key>
+            <string>(?ix)(\{%-?)\s*(end(?:css|includecss|includehirescss))\s*(-?%\})</string>
+            <key>endCaptures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.section.tag.twig</string>
+                </dict>
+                <key>2</key>
+                <dict>
+                    <key>name</key>
+                    <string>keyword.control.twig</string>
+                </dict>
+                <key>3</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.section.tag.twig</string>
+                </dict>
+            </dict>
+            <key>name</key>
+            <string>source.css.embedded.twig</string>
+            <key>patterns</key>
+            <array>
+                <dict>
+                    <key>include</key>
+                    <string>source.css</string>
+                </dict>
+            </array>
+        </dict>
+        <dict>
             <key>include</key>
             <string>#embedded-code</string>
         </dict>
@@ -394,25 +447,6 @@
                 <dict>
                 <key>include</key>
                 <string>source.js</string>
-                </dict>
-            </array>
-        </dict>
-        <dict>
-            <key>begin</key>
-            <string>(?ix)   # Enable free spacing mode, case insensitive
-                        (?&lt;=\{\%\scss\s\%\}|\{\%\sincludecss\s\%\}|\{\%\sincludehirescss\s\%\})
-                        </string>
-            <key>comment</key>
-            <string>Add CSS support to set tags that use the pattern "css" in their name</string>
-            <key>end</key>
-            <string>(?ix)(?=\{\%\sendcss\s\%\}|\{\%\sendincludecss\s\%\}|\{\%\sendincludehirescss\s\%\})</string>
-            <key>name</key>
-            <string>source.css.embedded.twig</string>
-            <key>patterns</key>
-            <array>
-                <dict>
-                    <key>include</key>
-                    <string>source.css</string>
                 </dict>
             </array>
         </dict>


### PR DESCRIPTION
Closes #56.

## Summary
- Move the Twig CSS embedded grammar rule before the generic embedded-code matcher so `{% css %}` starts a CSS scope.
- Consume `{% endcss %}`, `{% endincludecss %}`, and `{% endincludehirescss %}` as closing Twig tags so following lines return to normal Twig/HTML highlighting.
- Add begin/end captures for Twig punctuation and keywords.

## Verification
- `plutil -lint src/syntaxes/twig.tmLanguage`
- `npm run build`
- Tokenized a sample `{% css %}` / `{% endcss %}` Twig block locally with `vscode-textmate` and confirmed HTML after the end tag no longer carries the embedded CSS scope.